### PR TITLE
Add health check endpoint to chat server

### DIFF
--- a/cmd/chatserver/main.go
+++ b/cmd/chatserver/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 )
 
@@ -17,5 +18,5 @@ func main() {
 
 	fmt.Println("Running on port 8000")
 
-	http.ListenAndServe(":8000", nil)
+	log.Fatal(http.ListenAndServe(":8000", nil))
 }

--- a/cmd/chatserver/main.go
+++ b/cmd/chatserver/main.go
@@ -12,6 +12,9 @@ func main() {
 	// Initialize the chat server
 	fmt.Println("Starting chat server...")
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
 	})

--- a/cmd/chatserver/main.go
+++ b/cmd/chatserver/main.go
@@ -2,10 +2,20 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
 func main() {
 	// Initialize the chat server
 	fmt.Println("Starting chat server...")
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "healthy"})
+	})
+
+	fmt.Println("Running on port 8000")
+
+	http.ListenAndServe(":8000", nil)
 }


### PR DESCRIPTION
Introduce a health check endpoint that returns the server's status as healthy in JSON format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "/health" endpoint that returns the server's health status in JSON format.
  * The server now starts an HTTP service on port 8000 and logs its startup and any critical errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->