### PR TITLE
Support pagination in GetMessagesByRoom

### DIFF
--- a/internal/domain/repository/message.go
+++ b/internal/domain/repository/message.go
@@ -10,5 +10,5 @@ import (
 type MessageRepository interface {
 	CreateMessage(ctx context.Context, msg *models.Message) error
 	GetMessageByID(ctx context.Context, id string) (*models.Message, error)
-	GetMessagesByRoom(ctx context.Context, roomID string) ([]*models.Message, error)
+	GetMessagesByRoom(ctx context.Context, roomID string, limit, offset int) ([]*models.Message, error)
 }

--- a/internal/handlers/message_handler.go
+++ b/internal/handlers/message_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"z-chat/internal/domain/repository"
 
 	"github.com/go-chi/chi/v5"
@@ -30,9 +31,22 @@ func (h *MessageHandler) GetMessagesByRoom(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "roomID is required", http.StatusBadRequest)
 		return
 	}
+	pageStr := r.URL.Query().Get("page")
+	limitStr := r.URL.Query().Get("limit")
+
+	page, err := strconv.Atoi(pageStr)
+
+	if err != nil || page < 1 {
+		page = 1
+	}
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil || limit < 1 {
+		limit = 20
+	}
+	offset := (page - 1) * limit
 
 	// Retrieve messages from repository
-	messages, err := h.repo.GetMessagesByRoom(r.Context(), roomID)
+	messages, err := h.repo.GetMessagesByRoom(r.Context(), roomID, limit, offset)
 	if err != nil {
 		http.Error(w, "failed to get messages: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/hub/client_test.go
+++ b/internal/hub/client_test.go
@@ -32,8 +32,8 @@ func (m *mockMessageRepositoryClientTest) GetMessages() ([]models.Message, error
 	return nil, nil
 }
 
-func (m *mockMessageRepositoryClientTest) GetMessagesByRoom(_ context.Context, _ string) ([]*models.Message, error) {
-	return nil, nil
+func (m *mockMessageRepositoryClientTest) GetMessagesByRoom(_ context.Context, _ string, _ int, _ int) ([]*models.Message, error) {
+	return []*models.Message{}, nil
 }
 
 func TestNewClient(t *testing.T) {

--- a/internal/storage/postgres/message_repository.go
+++ b/internal/storage/postgres/message_repository.go
@@ -65,14 +65,16 @@ func (m *MessageRepository) GetMessageByID(ctx context.Context, id string) (*mod
 // Returns:
 //   - []*models.Message: A slice of message pointers for the specified room
 //   - error: Any error encountered during the query execution
-func (m *MessageRepository) GetMessagesByRoom(ctx context.Context, roomID string) ([]*models.Message, error) {
+func (m *MessageRepository) GetMessagesByRoom(ctx context.Context, roomID string, limit, offset int) ([]*models.Message, error) {
 	query := `
-	SELECT id, sender, receiver, content, created_at, updated_at, room_id
-	FROM messages
-	WHERE room_id = $1
-	ORDER BY created_at ASC
+		SELECT id, sender, receiver, content, created_at, updated_at, room_id
+		FROM messages
+		WHERE room_id = $1
+		ORDER BY created_at DESC
+		LIMIT $2 OFFSET $3
 	`
-	rows, err := m.db.Query(ctx, query, roomID)
+
+	rows, err := m.db.Query(ctx, query, roomID, limit, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -80,19 +82,14 @@ func (m *MessageRepository) GetMessagesByRoom(ctx context.Context, roomID string
 
 	var messages []*models.Message
 	for rows.Next() {
-		var msg models.Message
+		msg := new(models.Message)
 		if err := rows.Scan(
-			&msg.ID,
-			&msg.Sender,
-			&msg.Receiver,
-			&msg.Content,
-			&msg.CreatedAt,
-			&msg.UpdatedAt,
-			&msg.RoomID,
+			&msg.ID, &msg.Sender, &msg.Receiver, &msg.Content,
+			&msg.CreatedAt, &msg.UpdatedAt, &msg.RoomID,
 		); err != nil {
 			return nil, err
 		}
-		messages = append(messages, &msg)
+		messages = append(messages, msg)
 	}
 
 	return messages, nil


### PR DESCRIPTION
Enhance the GetMessagesByRoom function to accept pagination parameters, allowing clients to specify limits and offsets for message retrieval. This improves the efficiency of message fetching in chat rooms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support when retrieving messages by room, allowing users to specify page and limit parameters for more efficient browsing of message history.

* **Bug Fixes**
  * Improved message ordering to display the most recent messages first when viewing a room’s message list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->